### PR TITLE
fix: skip redundant save on Entity.load()

### DIFF
--- a/ic_python_db/entity.py
+++ b/ic_python_db/entity.py
@@ -180,7 +180,8 @@ class Entity:
                 setattr(self, k, v)
         self._do_not_save = False
 
-        self._save()
+        if not self._loaded:
+            self._save()
 
     @classmethod
     def new(cls, **kwargs):
@@ -385,6 +386,10 @@ class Entity:
 
         # Create instance first
         entity = cls(**data, _loaded=True)
+
+        # If migration was applied, persist the migrated data
+        if stored_version != current_version:
+            entity._save()
 
         # Restore legacy "relations" block if present in serialized data.
         # Otherwise keep the _relations that __init__ already populated


### PR DESCRIPTION
## Summary

Every `Entity.load()` was triggering a full re-serialization and write-back via `__init__` → `_save()`, even though the data was just read from storage.

### Before (per load)
```
storage.get → json.loads → __init__ → _save() → serialize() → json.dumps → storage.insert
```
- 1× `json.loads` (read)
- 1× `serialize()` (Python dict construction, MRO walk)
- 1× `json.dumps` (redundant write-back)
- 1× `storage.insert` (redundant StableBTreeMap write on canister)
- 1× audit `json.dumps` (if audit enabled)

### After (per load)
```
storage.get → json.loads → __init__ → done
```
- 1× `json.loads` (read)

### Changes

1. **`__init__`**: Skip `_save()` when `_loaded=True` — the data is already in storage.
2. **`Entity.load()`**: Explicitly call `_save()` after migration, so migrated data is still persisted.

### Test results
106 passed, 3 pre-existing failures (unrelated `TestDatabase.setUp` issue when run via pytest).

Closes #1